### PR TITLE
CSV output with directory creation option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,9 +103,11 @@ dist
 # TernJS port file
 .tern-port
 
-#IDE 
-.idea 
+#IDE
+.idea
 .vs
 
-#build 
+#build
 build
+
+test-reports

--- a/src/MemTrace.ts
+++ b/src/MemTrace.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import os from 'os';
 import memoryUse = NodeJS.MemoryUsage;
 
@@ -159,8 +160,18 @@ export function exportTrace(): ExportMemoryRecord[] | undefined {
   return undefined;
 }
 
-export function exportTraceToCSV(fileName: string) {
+export interface CsvExportOptions {
+  makeDirectories?: boolean
+}
+
+export function exportTraceToCSV(fileName: string, options?: CsvExportOptions) {
   if (tracer !== undefined) {
+    const dir = path.dirname(fileName);
+
+    if (options?.makeDirectories && !fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+
     const result = tracer.exportTracesAsCSVText();
     fs.writeFileSync(fileName, result);
   }

--- a/src/test/tracing-test.test.ts
+++ b/src/test/tracing-test.test.ts
@@ -17,5 +17,7 @@ test('test tracing', () => {
     console.debug(`record 2:${exportedTraces[1].heapUsed}`);
     console.debug(`Memory change: ${JSON.stringify(exportedTraces[4].heapUsed - exportedTraces[0].heapUsed)}`);
   }
-  exportTraceToCSV('test.csv');
+  exportTraceToCSV('test-reports/test.csv', {
+    makeDirectories: true
+  });
 });


### PR DESCRIPTION
* Running `npm test` generated the test CSV in the project root.
* It wasn't in .gitignore, so was floating
* This change has the test report be placed in a known directory (also in .gitignore)
* Also have the test report directories be created automatically if required.
